### PR TITLE
Changed delete method declaration to fix ie issues.

### DIFF
--- a/set.js
+++ b/set.js
@@ -44,7 +44,7 @@ Set.prototype.remove = function remove(val) {
     for (var i = 0; i < arguments.length; i++)
       delete this.set[arguments[i]];
 };
-Set.prototype.delete = Set.prototype.remove;
+Set.prototype['delete'] = Set.prototype.remove;
 
 Set.prototype.clear = function clear() {
   this.set = {};


### PR DESCRIPTION
You cannot use a reserved keyword as any variable or property name in older versions of IE.

So the declaration of the delete method on Set causes errors in older versions of IE. 
